### PR TITLE
Dev 4168 med2image + container + django py3.10 (3.7 call)

### DIFF
--- a/bin/create_venv.sh
+++ b/bin/create_venv.sh
@@ -2,13 +2,14 @@
 #requirements
 echo "#sudo apt-get install python3-pip"
 echo "#sudo apt-get install python3-venv"
-
-python3 -m venv ~/med2image_venv
+VENV_BASE_FOLDER=/usr/src/app/med2image
+rm -rf $VENV_BASE_FOLDER/med2image_venv
+python3.7 -m venv $VENV_BASE_FOLDER/med2image_venv
 
 #ativar virtual env
-. ~/med2image_venv/bin/activate
+. $VENV_BASE_FOLDER/med2image_venv/bin/activate
 
-#instalar as dependências de maneira rápida
-echo "#pip install --upgrade pip"
+#upgrade do pip dentro do venv para poder rodar com py3.7 mesmo sendo py3.10 no container
+pip3 install --upgrade pip
 pip3 install med2image
 

--- a/bin/med2image
+++ b/bin/med2image
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # NAME
 #

--- a/bin/run_seg_med2image
+++ b/bin/run_seg_med2image
@@ -70,7 +70,10 @@ then bluelimit_call=""
 else bluelimit_call="--blueLimit $blueLimit"
 fi
 
-. ~/med2image_venv/bin/activate
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+VENV_BASE_FOLDER=/usr/src/app/med2image
 
-$DIR/med2image -i $input_file -d $out_dir -t png -r --type $proj_type $colormap_call $bluelimit_call #-s 377 # -s m/<int sliceNumber> soh pra testes (converte soh o slice do meio)
+. $VENV_BASE_FOLDER/med2image_venv/bin/activate
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "------------$DIR"
+# $DIR/med2image -i $input_file -d $out_dir -t png -r --type $proj_type $colormap_call $bluelimit_call #-s 377 # -s m/<int sliceNumber> soh pra testes (converte soh o slice do meio)
+python $DIR/med2image -i $input_file -d $out_dir -t png -r --type $proj_type $colormap_call $bluelimit_call #-s 377 # -s m/<int sliceNumber> soh pra testes (converte soh o slice do meio)


### PR DESCRIPTION
altera pastas onde é criado o venv (coerente com container) e especifica python 3.7 para não usar o 3.10 do container principal para o qual não há suporte